### PR TITLE
Improve watchdog cleanup

### DIFF
--- a/run_testchrone_on_csv_change.py
+++ b/run_testchrone_on_csv_change.py
@@ -2,6 +2,7 @@ import time
 import os
 import subprocess
 import sys
+import signal
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
 
@@ -26,6 +27,7 @@ CSV_FILE_PATH = os.path.join(SCRIPT_DIR, CSV_FILENAME)
 TARGET_SCRIPT_PATH = os.path.join(SCRIPT_DIR, TARGET_SCRIPT_FILENAME)
 # Absolute path to the log file for the target script
 TARGET_SCRIPT_LOG_PATH = os.path.join(SCRIPT_DIR, TARGET_SCRIPT_LOG_FILENAME)
+PID_FILE = os.path.join(SCRIPT_DIR, 'test_chrome.pid')
 
 
 class CSVChangeHandler(FileSystemEventHandler):
@@ -34,6 +36,40 @@ class CSVChangeHandler(FileSystemEventHandler):
         self.running_process = None  # Stores the subprocess.Popen object
         self.last_launch_time = 0 # To implement a simple cooldown for watchdog itself if needed
         self.cooldown_seconds = 5 # Cooldown for watchdog reacting to multiple quick changes
+        self._cleanup_previous_process()
+
+    def _terminate_pid(self, pid: int):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            start_time = time.time()
+            while time.time() - start_time < 5:
+                try:
+                    os.kill(pid, 0)
+                    time.sleep(0.5)
+                except OSError:
+                    break
+            else:
+                os.kill(pid, signal.SIGKILL)
+                print(f"Watchdog: Force killed PID {pid} after timeout.")
+            print(f"Watchdog: Terminated previous PID {pid}.")
+        except ProcessLookupError:
+            print(f"Watchdog: Previous PID {pid} not running.")
+        except Exception as e:
+            print(f"Watchdog: Error terminating PID {pid}: {e}")
+
+    def _cleanup_previous_process(self):
+        if os.path.exists(PID_FILE):
+            try:
+                with open(PID_FILE, 'r') as pf:
+                    old_pid = int(pf.read().strip())
+                self._terminate_pid(old_pid)
+            except Exception as e:
+                print(f"Watchdog: Failed to read PID file: {e}")
+            finally:
+                try:
+                    os.remove(PID_FILE)
+                except FileNotFoundError:
+                    pass
 
     def on_modified(self, event):
         if event.is_directory:
@@ -69,9 +105,13 @@ class CSVChangeHandler(FileSystemEventHandler):
                 return
 
             if self.running_process and self.running_process.poll() is None:
-                print(f"Watchdog: Previous '{TARGET_SCRIPT_FILENAME}' (PID: {self.running_process.pid}) is still running. "
-                      "Skipping new launch.")
-                return
+                print(f"Watchdog: Terminating previous '{TARGET_SCRIPT_FILENAME}' (PID: {self.running_process.pid})...")
+                self._terminate_pid(self.running_process.pid)
+                self.running_process = None
+                try:
+                    os.remove(PID_FILE)
+                except FileNotFoundError:
+                    pass
 
             print(f"Watchdog: '{CSV_FILENAME}' content changed (mtime: {current_mtime}). Launching '{TARGET_SCRIPT_FILENAME}'...")
             try:
@@ -85,6 +125,8 @@ class CSVChangeHandler(FileSystemEventHandler):
                         text=True,
                         cwd=SCRIPT_DIR
                     )
+                    with open(PID_FILE, 'w') as pf:
+                        pf.write(str(self.running_process.pid))
                     self.last_launch_time = current_time # Update last launch time
                     print(f"Watchdog: Successfully launched '{TARGET_SCRIPT_FILENAME}' with PID {self.running_process.pid}. "
                           f"Output logged to '{TARGET_SCRIPT_LOG_PATH}'.")
@@ -145,4 +187,9 @@ if __name__ == "__main__":
                     print(f"Watchdog: Error during SIGKILL for PID {event_handler.running_process.pid}: {e_kill}")
             except Exception as e_term:
                  print(f"Watchdog: Error during termination for PID {event_handler.running_process.pid}: {e_term}")
+        if os.path.exists(PID_FILE):
+            try:
+                os.remove(PID_FILE)
+            except Exception:
+                pass
         print("Watchdog: Exiting.")


### PR DESCRIPTION
## Summary
- terminate any previous watchdog process when starting a new one
- store watchdog PIDs in `.pid` files
- clean up PID files and log when processes end

## Testing
- `python3 -m py_compile "SniperX V2.py" run_testchrone_on_csv_change.py run_riskdetector_on_cluster_change.py`

------
https://chatgpt.com/codex/tasks/task_e_6851f4a6f8c0832cbc9df02075beabdb