### PR TITLE
Filter tokens by price impact threshold

### DIFF
--- a/Monitoring.py
+++ b/Monitoring.py
@@ -134,6 +134,7 @@ STAGNATION_PRICE_THRESHOLD_PERCENT = 0.80 # e.g., price is 20% below baseline
 NO_BUY_SIGNAL_TIMEOUT_SECONDS = 60    # 1 minute
 STAGNATION_TIMEOUT_SECONDS = 60       # 1 minute
 BUY_SIGNAL_PRICE_INCREASE_PERCENT = 1.01 # 1% increase from baseline to consider it a buy signal
+PRICE_IMPACT_THRESHOLD_MONITOR = 65.0  # Minimum price impact percentage to monitor
 
 # --- Global State Variables (Token Lifecycle Specific) ---
 g_token_start_time = None
@@ -164,8 +165,15 @@ def load_token_from_csv(csv_file_path):
 
             for row in reader:  # Iterate through all rows
                 mint_address = row.get('Address', '').strip()
-                
-                if mint_address:  # If this row has a valid address
+
+                # Filter on price impact
+                price_impact_str = row.get('Price_Impact_Cluster_Sell_Percent', '').strip()
+                try:
+                    price_impact_val = float(price_impact_str)
+                except (ValueError, TypeError):
+                    continue
+
+                if mint_address and price_impact_val >= PRICE_IMPACT_THRESHOLD_MONITOR:
                     token_name_from_row = row.get('Name', '').strip()
                     latest_mint_address = mint_address
                     # Default name to address if 'Name' column is empty or not found for this row


### PR DESCRIPTION
## Summary
- add `PRICE_IMPACT_THRESHOLD_MONITOR` constant
- only load tokens with a `Price_Impact_Cluster_Sell_Percent` above this threshold

## Testing
- `python -m py_compile Monitoring.py`

------
https://chatgpt.com/codex/tasks/task_e_6853102eb884832c98fe7363fbc84a1c