### PR TITLE
Remove duplicate token monitor globals

### DIFF
--- a/Monitoring.py
+++ b/Monitoring.py
@@ -55,8 +55,6 @@ BUY_SIGNAL_TIMEOUT_SECONDS = 300  # 5 minutes timeout for no buy signal
 
 g_current_tasks = []  # Holds tasks like listener, trader, csv_checker for cancellation
 g_processing_token = False  # Tracks if we're currently processing a token
-g_token_monitor_start_time = 0  # Timestamp when monitoring of current token started
-BUY_SIGNAL_TIMEOUT_SECONDS = 300  # 5 minutes timeout for no buy signal
 
 # Custom exception for signaling restart
 class RestartRequired(Exception):


### PR DESCRIPTION
## Summary
- clean up repeated definitions of monitoring timeout variables

## Testing
- `python -m py_compile Monitoring.py`


------
https://chatgpt.com/codex/tasks/task_e_685be0ccab60832ca227d73051e45873