### PR TITLE
Fix duplicate python-telegram-bot version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot>=20.0
+python-telegram-bot==20.5
 python-dotenv>=0.19.0
 solders==0.23.0
 solana>=0.30.0
@@ -15,5 +15,4 @@ tox==4.25.0
 webdriver-manager==4.0.1
 aiohttp==3.9.1
 loguru==0.7.2
-python-telegram-bot==20.5
 watchdog>=3.0.0


### PR DESCRIPTION
## Summary
- remove duplicate python-telegram-bot line
- pin python-telegram-bot to 20.5

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be0d27aa8832c8806d1ae7d7bc56b