### PR TITLE
Verify PID before clearing stale watchdog lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ pip install -U "python-telegram-bot>=20.0"
 
 ## Monitoring Watchdog
 
-`run_monitoring_on_analysis_change.py` monitors `token_risk_analysis.csv` and normally restarts `Monitoring.py` when the file changes. The watchdog now checks for the `monitoring_active.lock` file created by `Monitoring.py`. If the lock exists and the process is still running, the watchdog skips the restart to avoid interrupting an active token analysis.
+`run_monitoring_on_analysis_change.py` monitors `token_risk_analysis.csv` and normally restarts `Monitoring.py` when the file changes. The watchdog now checks for the `monitoring_active.lock` file created by `Monitoring.py`. If the lock exists and the process is still running, the watchdog skips the restart to avoid interrupting an active token analysis. If the PID recorded in the lock file no longer represents a running process, the stale lock file is removed before launching `Monitoring.py` again.


### PR DESCRIPTION
## Summary
- add helper to check whether a PID is running
- validate the PID stored in `monitoring_active.lock` before removing it
- document this behaviour in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f6f08e5f4832c9821be7e5acecb62