### PR TITLE
Fix cluster summaries & improve token queue

### DIFF
--- a/risk_detector.py
+++ b/risk_detector.py
@@ -178,21 +178,37 @@ def save_processed_tokens(filepath, token_addresses):
         logging.error(f"Error writing processed tokens to {filepath}: {e}")
 
 def load_cluster_summaries(path):
+    """Load summary rows keyed by token address from cluster_summaries.csv."""
     if not os.path.exists(path):
         logging.error(f"Cluster summary file not found at {path}")
         return {}
-    summaries = {}
+
+    summaries: dict[str, dict] = {}
     try:
-        with open(path, 'r', encoding='utf-8-sig') as f: 
+        with open(path, "r", encoding="utf-8-sig") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                if 'Token_Address' in row:
-                    summaries[row['Token_Address']] = row
-                else:
-                    logging.warning(f"Skipping row in cluster summary due to missing 'Token_Address': {row}")
-            logging.info(f"Successfully loaded {len(summaries)} entries from {path}")
+                token_addr = row.get("Token_Address")
+                if not token_addr:
+                    logging.warning(
+                        f"Skipping row in cluster summary due to missing 'Token_Address': {row}"
+                    )
+                    continue
+
+                rank_val = (row.get("Rank", "").strip() or "").upper()
+                addr_type = (row.get("Address_Type", "").strip() or "").upper()
+
+                # Keep only the summary row for each token to avoid overwriting
+                if rank_val == "SUMMARY" or addr_type == "SUMMARY":
+                    summaries[token_addr] = row
+
+            logging.info(
+                f"Successfully loaded {len(summaries)} summary entries from {path}"
+            )
     except Exception as e:
-        logging.error(f"Error loading cluster summaries from {path}: {e}", exc_info=True)
+        logging.error(
+            f"Error loading cluster summaries from {path}: {e}", exc_info=True
+        )
     return summaries
 
 def run_full_risk_analysis():

--- a/test_chrome.py
+++ b/test_chrome.py
@@ -36,6 +36,8 @@ CSV_FILE = 'sniperx_results_1m.csv'
 OPENED_TOKENS_FILE = 'opened_tokens.txt'
 EXTRACTED_DATA_DIR = 'bubblemaps_token_data'
 CLUSTER_SUMMARY_FILE = 'cluster_summaries.csv'
+CSV_CURSOR_FILE = 'sniperx_csv_cursor.txt'
+BMAP_SCREENSHOT_DIR = 'bubblemaps_screens'
 
 # XPATH used to detect the presence of a cluster icon inside an address row.
 # If an element matching this XPATH exists within the MuiBox container then the
@@ -57,6 +59,7 @@ MAX_BUBBLEMAPS_RETRIES = 3
 
 PROCESSED_TOKENS_LOCK = threading.Lock()
 CLUSTER_SUMMARY_LOCK = threading.Lock()
+CSV_CURSOR_LOCK = threading.Lock()
 
 def setup_logging():
     logging.basicConfig(
@@ -106,52 +109,69 @@ def save_processed_token_threadsafe(filepath: str, token_address: str):
     except Exception as e:
         logging.error(f"Error saving processed token {token_address} to {filepath}: {e}")
 
+def load_csv_cursor(filepath: str) -> int:
+    with CSV_CURSOR_LOCK:
+        if not os.path.exists(filepath):
+            return 0
+        try:
+            with open(filepath, 'r', encoding='utf-8') as f:
+                val = f.read().strip()
+                return int(val) if val else 0
+        except Exception as e:
+            logging.error(f"Error reading CSV cursor from {filepath}: {e}")
+            return 0
+
+def save_csv_cursor(filepath: str, position: int):
+    with CSV_CURSOR_LOCK:
+        try:
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.write(str(position))
+        except Exception as e:
+            logging.error(f"Error saving CSV cursor to {filepath}: {e}")
+
 def get_new_tokens_from_csv_threadsafe(csv_filepath: str, current_processed_tokens: set) -> list:
-    new_tokens = []
+    new_tokens: list[str] = []
     if not os.path.exists(csv_filepath):
         logging.warning(f"Monitored CSV file {csv_filepath} not found.")
         return new_tokens
-    
+
     try:
-        with open(csv_filepath, mode='r', newline='', encoding='utf-8') as f:
-            # Read all lines to get the latest content
+        with open(csv_filepath, "r", newline="", encoding="utf-8") as f:
             lines = f.readlines()
-            if not lines:
-                return new_tokens
 
-            # Skip header if present
-            start_idx = 1 if lines[0].strip().lower().startswith('address') else 0
-            processed_lines = set()
+        if not lines:
+            return new_tokens
 
-            # Process lines in reverse order to get the most recent entries first
-            for line in reversed(lines[start_idx:]):
-                line = line.strip()
-                if not line:  # Skip empty lines
-                    continue
+        header_offset = 1 if lines[0].strip().lower().startswith("address") else 0
+        total_lines = len(lines)
 
-                # Extract token address - handle both CSV and plain text formats
-                if ',' in line:
-                    token_address = line.split(',')[0].strip()
-                else:
-                    token_address = line.strip()
+        cursor = load_csv_cursor(CSV_CURSOR_FILE)
+        if cursor < header_offset or cursor > total_lines:
+            cursor = header_offset
 
-                # Skip if we've already processed this token in this batch
-                if token_address in processed_lines:
-                    continue
-                    
-                processed_lines.add(token_address)
+        processed_in_batch = set()
+        for idx in range(cursor, total_lines):
+            line = lines[idx].strip()
+            if not line:
+                continue
 
-                if token_address and token_address not in current_processed_tokens:
-                    new_tokens.append(token_address)
-                    logging.info(f"Found new token to process: {token_address}")
-                    
-                    # Limit the number of new tokens to process in one batch
-                    if len(new_tokens) >= 10:  # Process max 10 new tokens at a time
-                        break
+            token_address = line.split(',')[0].strip() if ',' in line else line
 
+            if token_address in processed_in_batch:
+                continue
+            processed_in_batch.add(token_address)
+
+            if token_address and token_address not in current_processed_tokens:
+                new_tokens.append(token_address)
+                logging.info(f"Found new token to process: {token_address}")
+                cursor = idx + 1
+                if len(new_tokens) >= 10:
+                    break
+
+        save_csv_cursor(CSV_CURSOR_FILE, cursor)
     except Exception as e:
         logging.error(f"Error reading CSV file {csv_filepath}: {e}", exc_info=True)
-    
+
     logging.info(f"Found {len(new_tokens)} new tokens to process")
     return new_tokens
 
@@ -190,6 +210,18 @@ def click_element_with_fallback(driver, element, timeout: int = 10, max_attempts
         time.sleep(0.5)
     logging.error(f"{log_prefix} Failed to click element after {max_attempts} attempts.")
     return False
+
+def capture_screenshot(driver, token_addr: str, context: str) -> None:
+    """Save a screenshot for debugging when a step fails."""
+    os.makedirs(BMAP_SCREENSHOT_DIR, exist_ok=True)
+    ts = int(time.time())
+    fname = f"{token_addr}_{context}_{ts}.png"
+    path = os.path.join(BMAP_SCREENSHOT_DIR, fname)
+    try:
+        driver.save_screenshot(path)
+        logging.info(f"[{threading.get_ident()}] Screenshot saved to {path}")
+    except Exception as e:
+        logging.error(f"[{threading.get_ident()}] Failed to save screenshot {path}: {e}")
 
 def ensure_address_list_panel_open(driver):
     """Ensure the Address List panel is expanded."""
@@ -993,8 +1025,11 @@ def process_single_token_threaded(token_address_with_config: tuple):
 
                 if not data_is_fresh:
                     logging.error(f"[{thread_id_str}] CRITICAL: Data not fresh after all checks and refreshes on attempt {attempt + 1}.")
-                    if attempt < MAX_BUBBLEMAPS_RETRIES - 1: continue
-                    else: return token_address, False
+                    capture_screenshot(thread_driver, token_address, "stale_data")
+                    if attempt < MAX_BUBBLEMAPS_RETRIES - 1:
+                        continue
+                    else:
+                        return token_address, False
 
                 # 3. Initial Data Extraction & Rank 01 Check
                 initial_data = extract_initial_address_list_data(thread_driver)

--- a/test_risk_calculations.py
+++ b/test_risk_calculations.py
@@ -1,0 +1,25 @@
+import math
+from pytest import approx
+from risk_detector import calculate_lp_percent, calculate_dump_risk_lp_vs_cluster, calculate_price_impact_cluster_sell, TOTAL_SUPPLY
+
+
+def test_calculate_lp_percent():
+    val = calculate_lp_percent(1000, 1)
+    expected = ((1000 / 2) / 1) / TOTAL_SUPPLY * 100
+    assert val == approx(expected)
+    assert calculate_lp_percent(None, 1) == 0.0
+    assert calculate_lp_percent(1000, 0) == 0.0
+
+
+def test_calculate_dump_risk_lp_vs_cluster():
+    assert calculate_dump_risk_lp_vs_cluster(20, 10) == approx(200.0)
+    assert calculate_dump_risk_lp_vs_cluster(0, 10) == 0.0
+    assert calculate_dump_risk_lp_vs_cluster(10, 0) == math.inf
+    assert calculate_dump_risk_lp_vs_cluster(None, 10) == 0.0
+
+
+def test_calculate_price_impact_cluster_sell():
+    assert calculate_price_impact_cluster_sell(100, 100) == approx((1 - (100 / 200) ** 2) * 100)
+    assert calculate_price_impact_cluster_sell(0, 10) == 100.0
+    assert calculate_price_impact_cluster_sell(None, 100) == 0.0
+    assert calculate_price_impact_cluster_sell(100, 0) == 0.0


### PR DESCRIPTION
## Summary
- keep only SUMMARY rows when loading cluster summaries
- persist position when scanning sniperx CSV
- add screenshot capture on stale Bubblemaps data
- add simple unit tests for risk calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b1bd29e4832cb05d47f00bd4d1af